### PR TITLE
refactor: use controller to save tasks

### DIFF
--- a/lib/controllers/add_task_controller.dart
+++ b/lib/controllers/add_task_controller.dart
@@ -85,14 +85,14 @@ class AddTaskController extends GetxController {
           children: [
             Icon(Icons.warning_amber, color: Colors.orange.shade600),
             const SizedBox(width: 8),
-            Text('confirmdeletesu'.tr),
+            Text('comfirmdelete'.tr),
           ],
         ),
         content: Text('confirmdeletesubtask'.tr),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text('cancle'.tr),
+            child: Text('cancel'.tr),
           ),
           ElevatedButton(
             onPressed: () => Navigator.pop(ctx, true),

--- a/lib/controllers/add_task_controller.dart
+++ b/lib/controllers/add_task_controller.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/task_model.dart';
+
+class AddTaskController extends GetxController {
+  final TextEditingController titleController = TextEditingController();
+
+  final priority = 'Low'.obs;
+  final startDate = DateTime.now().obs;
+  final endDate = DateTime.now().add(const Duration(days: 1)).obs;
+  final checklist = <Map<String, dynamic>>[].obs;
+  final isLoading = false.obs;
+
+  final Map<String, Color> priorityColors = {
+    'Low': Colors.green,
+    'Medium': Colors.orange,
+    'High': Colors.red,
+  };
+
+  final Map<String, IconData> priorityIcons = {
+    'Low': Icons.keyboard_arrow_down,
+    'Medium': Icons.remove,
+    'High': Icons.keyboard_arrow_up,
+  };
+
+  @override
+  void onClose() {
+    titleController.dispose();
+    super.onClose();
+  }
+
+  Future<void> pickDate(BuildContext context, bool isStart) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: isStart ? startDate.value : endDate.value,
+      firstDate: DateTime.now(),
+      lastDate: DateTime(2100),
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            colorScheme: Theme.of(context)
+                .colorScheme
+                .copyWith(primary: priorityColors[priority.value]),
+          ),
+          child: child!,
+        );
+      },
+    );
+
+    if (picked != null) {
+      if (isStart) {
+        startDate.value = picked;
+        if (endDate.value.isBefore(startDate.value)) {
+          endDate.value = startDate.value.add(const Duration(days: 1));
+        }
+      } else {
+        if (picked.isBefore(startDate.value)) {
+          showErrorSnackbar('วันที่สิ้นสุดต้องไม่น้อยกว่าวันที่เริ่ม');
+          return;
+        }
+        endDate.value = picked;
+      }
+    }
+  }
+
+  void addChecklistItem() {
+    checklist.add({
+      "title": "",
+      "description": "",
+      "done": false,
+      "expanded": true,
+      "id": DateTime.now().millisecondsSinceEpoch,
+    });
+  }
+
+  Future<void> removeChecklistItem(BuildContext context, int index) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        title: Row(
+          children: [
+            Icon(Icons.warning_amber, color: Colors.orange.shade600),
+            const SizedBox(width: 8),
+            Text('confirmdeletesu'.tr),
+          ],
+        ),
+        content: Text('confirmdeletesubtask'.tr),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text('cancle'.tr),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: Text('delete'.tr),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      checklist.removeAt(index);
+    }
+  }
+
+  void toggleChecklistExpansion(int index, bool expanded) {
+    checklist[index]["expanded"] = expanded;
+    checklist.refresh();
+  }
+
+  void toggleChecklistDone(int index, bool done) {
+    checklist[index]["done"] = done;
+    checklist.refresh();
+  }
+
+  void showErrorSnackbar(String message) {
+    Get.snackbar(
+      'เกิดข้อผิดพลาด ⚠️',
+      message,
+      backgroundColor: Colors.red.withOpacity(0.9),
+      colorText: Colors.white,
+      icon: const Icon(Icons.error_rounded, color: Colors.white),
+      duration: const Duration(seconds: 4),
+      snackPosition: SnackPosition.TOP,
+      margin: const EdgeInsets.all(16),
+      borderRadius: 12,
+      isDismissible: true,
+      dismissDirection: DismissDirection.horizontal,
+    );
+  }
+
+  Future<void> saveTask(GlobalKey<FormState> formKey, BuildContext context) async {
+    if (!formKey.currentState!.validate()) return;
+
+    isLoading.value = true;
+
+    try {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid == null) {
+        showErrorSnackbar('ไม่พบผู้ใช้');
+        return;
+      }
+
+      final task = TaskModel(
+        id: '',
+        title: titleController.text.trim(),
+        priority: priority.value,
+        startDate: startDate.value,
+        endDate: endDate.value,
+        status: 'todo',
+        uid: uid,
+        checklist: checklist.toList(),
+      );
+
+      await FirebaseFirestore.instance.collection('tasks').add(task.toJson());
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                    'สร้าง Task "${titleController.text.trim()}" เรียบร้อยแล้ว'),
+              ),
+            ],
+          ),
+          backgroundColor: Colors.green,
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      );
+
+      Get.back(result: true);
+    } catch (e) {
+      showErrorSnackbar('เกิดข้อผิดพลาดในการบันทึก: ${e.toString()}');
+      print('Error saving task: $e');
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}
+

--- a/lib/controllers/dashboard_controller.dart
+++ b/lib/controllers/dashboard_controller.dart
@@ -1,5 +1,8 @@
+import 'package:ai_task_project_manager/pages/auth/login_page.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:get/get.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tzdata;
@@ -149,12 +152,24 @@ class DashboardController extends GetxController {
   // ✅ อัปเดตสถานะ task
   Future<void> updateTaskStatus(String taskId, String status) async {
     try {
-      await _firestore.collection('tasks').doc(taskId).update({
-        'status': status,
-      });
-    } catch (e) {
+      final update = <String, dynamic>{'status': status};
+
+      if (status == 'done'){
+        update['completedAt'] = FieldValue.serverTimestamp();
+      }
+      else {
+        // update['completedAt'] = FieldValue.delete();
+      }
+
+      await _firestore.collection('tasks').doc(taskId).update(update);
+      Get.snackbar('Success', 'Change task status successfully',
+      backgroundColor: const Color.fromARGB(255, 119, 243, 123),
+      snackPosition: SnackPosition.BOTTOM 
+      );
+    }
+    catch (e) {
       print('Error updating task status: $e');
-      Get.snackbar('Error', 'ไม่สามารถเปลี่ยนสถานะ Task ได้');
+      Get.snackbar('Error', 'Cannot Change task status');
     }
   }
 

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -9,7 +9,7 @@ class TaskModel {
   final String status;
   final String uid;
   final List<Map<String, dynamic>>? checklist;
-  final String? category;
+  final DateTime? completedAt;
 
   TaskModel({
     required this.id,
@@ -20,7 +20,7 @@ class TaskModel {
     required this.status,
     required this.uid,
     required this.checklist,
-    this.category,
+    this.completedAt
   });
 
   factory TaskModel.fromJson(String id, Map<String, dynamic> json) {
@@ -35,7 +35,9 @@ class TaskModel {
       checklist: json['checklist'] != null
           ? List<Map<String, dynamic>>.from(json['checklist'])
           : [],
-          category: json['category'] ?? 'General',
+      completedAt: json['completedAt'] != null
+          ? (json['completedAt'] as Timestamp).toDate()
+          : null,
     );
   }
 
@@ -48,7 +50,7 @@ class TaskModel {
       'status': status,
       'uid': uid,
       'checklist': checklist ?? [],
-      'category': category ?? 'General',
+      if (completedAt != null) 'completedAt' : Timestamp.fromDate(completedAt!),
     };
   }
 
@@ -73,7 +75,6 @@ class TaskModel {
       status: status ?? this.status,
       uid: uid ?? this.uid,
       checklist: checklist ?? this.checklist,
-      category: category ?? this.category,
     );
   }
 }

--- a/lib/pages/add_task_page.dart
+++ b/lib/pages/add_task_page.dart
@@ -13,618 +13,870 @@ class _AddTaskPageState extends State<AddTaskPage>
     with TickerProviderStateMixin {
   final AddTaskController controller = Get.put(AddTaskController());
   final _formKey = GlobalKey<FormState>();
-  late AnimationController _animationController;
+  late AnimationController _fadeController;
+  late AnimationController _slideController;
   late Animation<double> _fadeAnimation;
+
+  // ใช้ธีมสีเขียวเหมือน TaskListPage
+  static const Color kPrimary1 = Color(0xFF10B981); // emerald-500
+  static const Color kPrimary2 = Color(0xFF059669); // emerald-600
 
   @override
   void initState() {
     super.initState();
-    _animationController = AnimationController(
-      duration: const Duration(milliseconds: 300),
+    _initAnimations();
+  }
+
+  void _initAnimations() {
+    _fadeController = AnimationController(
+      duration: const Duration(milliseconds: 600),
       vsync: this,
     );
-    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
-      CurvedAnimation(parent: _animationController, curve: Curves.easeInOut),
+    _slideController = AnimationController(
+      duration: const Duration(milliseconds: 800),
+      vsync: this,
     );
-    _animationController.forward();
+
+    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _fadeController, curve: Curves.easeOut),
+    );
+
+    _fadeController.forward();
+    _slideController.forward();
   }
 
   @override
   void dispose() {
-    _animationController.dispose();
+    _fadeController.dispose();
+    _slideController.dispose();
     super.dispose();
   }
 
   String _formatDate(DateTime date) {
     final months = [
       '',
-      'jan'.tr,
-      'feb'.tr,
-      'mar'.tr,
-      'apr'.tr,
-      'may'.tr,
-      'jun'.tr,
-      'jul'.tr,
-      'aug'.tr,
-      'sep'.tr,
-      'oct'.tr,
-      'nov'.tr,
-      'dec'.tr,
+      'jan'.tr, 'feb'.tr, 'mar'.tr, 'apr'.tr, 'may'.tr, 'jun'.tr,
+      'jul'.tr, 'aug'.tr, 'sep'.tr, 'oct'.tr, 'nov'.tr, 'dec'.tr,
     ];
     return '${date.day} ${months[date.month]} ${date.year + 543}';
+  }
+
+  Widget _buildGlassmorphismCard({
+    required Widget child,
+    double delay = 0.0,
+  }) {
+    return TweenAnimationBuilder<double>(
+      duration: Duration(milliseconds: 600 + (delay * 200).toInt()),
+      tween: Tween(begin: 0.0, end: 1.0),
+      builder: (context, value, child) {
+        return Transform.translate(
+          offset: Offset(0, 50 * (1 - value)),
+          child: Opacity(
+            opacity: value,
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 20),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(24),
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    Colors.white.withOpacity(0.9),
+                    Colors.white.withOpacity(0.8),
+                  ],
+                ),
+                border: Border.all(
+                  color: Colors.white.withOpacity(0.2),
+                  width: 1.5,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: kPrimary1.withOpacity(0.1),
+                    blurRadius: 20,
+                    offset: const Offset(0, 10),
+                  ),
+                ],
+              ),
+              child: child!,
+            ),
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+
+  Widget _buildSectionHeader({
+    required IconData icon,
+    required String title,
+    String? subtitle,
+    required List<Color> gradient,
+    Widget? action,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(colors: gradient),
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: gradient.first.withOpacity(0.3),
+                  blurRadius: 8,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Icon(icon, color: Colors.white, size: 24),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF2D3748),
+                  ),
+                ),
+                if (subtitle != null)
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey.shade600,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (action != null) action,
+        ],
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey.shade50,
-      appBar: AppBar(
-        elevation: 0,
-        backgroundColor: Colors.deepPurple,
-        foregroundColor: Colors.white,
-        title: Text(
-          'addnewtask'.tr,
-          style: TextStyle(fontWeight: FontWeight.w600, fontSize: 20),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [kPrimary1, kPrimary2, kPrimary2],
+          ),
         ),
-        centerTitle: true,
-        actions: [
-          Obx(() => controller.isLoading.value
-              ? const Padding(
-                  padding: EdgeInsets.all(16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+        child: SafeArea(
+          child: Column(
+            children: [
+              _buildModernAppBar(),
+              Expanded(
+                child: Container(
+                  margin: const EdgeInsets.only(top: 20),
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFF8FAFC),
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(30),
+                      topRight: Radius.circular(30),
+                    ),
                   ),
-                )
-              : const SizedBox()),
-        ],
-      ),
-      body: FadeTransition(
-        opacity: _fadeAnimation,
-        child: Form(
-          key: _formKey,
-          child: Obx(() => ListView(
-                padding: const EdgeInsets.all(20),
-                children: [
-              // Task Title Card
-              Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: controller.priorityColors[controller.priority.value]?.withOpacity(0.1),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Icon(
-                              Icons.task_alt,
-                              color: controller.priorityColors[controller.priority.value],
-                              size: 20,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Text(
-                            'taskdetails'.tr,
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      TextFormField(
-                        controller: controller.titleController,
-                        decoration: InputDecoration(
-                          labelText: 'taskname'.tr,
-                          hintText: 'hintnametask'.tr,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          prefixIcon: const Icon(Icons.edit),
-                          filled: true,
-                          fillColor: Colors.grey.shade50,
-                        ),
-                        validator: (value) {
-                          if (value == null || value.trim().isEmpty) {
-                            return 'inserttaskname'.tr;
-                          }
-                          return null;
-                        },
-                        textInputAction: TextInputAction.next,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Priority and Dates Card
-              Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: Colors.blue.withOpacity(0.1),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: const Icon(
-                              Icons.settings,
-                              color: Colors.blue,
-                              size: 20,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Text(
-                            'settings'.tr,
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-
-                      // Priority Selector
-                      Text(
-                        'priority'.tr,
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                          color: Colors.grey,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Container(
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(12),
-                          border: Border.all(color: Colors.grey.shade300),
-                        ),
-                        child: Row(
-                          children: ['low'.tr, 'medium'.tr, 'high'.tr].map((p) {
-                            final isSelected = controller.priority.value == p;
-                            return Expanded(
-                              child: GestureDetector(
-                                onTap: () => controller.priority.value = p,
-                                child: Container(
-                                  padding: const EdgeInsets.symmetric(
-                                    vertical: 12,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: isSelected
-                                        ? controller.priorityColors[p]
-                                        : Colors.transparent,
-                                    borderRadius: BorderRadius.circular(11),
-                                  ),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        controller.priorityIcons[p],
-                                        color: isSelected
-                                            ? Colors.white
-                                            : controller.priorityColors[p],
-                                        size: 18,
-                                      ),
-                                      const SizedBox(width: 4),
-                                      Text(
-                                        p.toLowerCase().tr,
-                                        style: TextStyle(
-                                          color: isSelected
-                                              ? Colors.white
-                                              : controller.priorityColors[p],
-                                          fontWeight: FontWeight.w500,
-                                        ),
-                                      ),
+                  child: Form(
+                    key: _formKey,
+                    child: Obx(() => ListView(
+                          padding: const EdgeInsets.all(20),
+                          children: [
+                            // Task Title Section
+                            _buildGlassmorphismCard(
+                              delay: 0.0,
+                              child: Column(
+                                children: [
+                                  _buildSectionHeader(
+                                    icon: Icons.edit_document,
+                                    title: 'taskdetails'.tr,
+                                    gradient: [
+                                      controller.priorityColors[controller.priority.value] ?? kPrimary1,
+                                      (controller.priorityColors[controller.priority.value] ?? kPrimary1).withOpacity(0.8),
                                     ],
                                   ),
-                                ),
-                              ),
-                            );
-                          }).toList(),
-                        ),
-                      ),
-
-                      const SizedBox(height: 20),
-
-                      // Date Pickers
-                      Row(
-                        children: [
-                          Expanded(
-                            child: GestureDetector(
-                              onTap: () => controller.pickDate(context, true),
-                              child: Container(
-                                padding: const EdgeInsets.all(16),
-                                decoration: BoxDecoration(
-                                  color: Colors.grey.shade50,
-                                  borderRadius: BorderRadius.circular(12),
-                                  border: Border.all(
-                                    color: Colors.grey.shade300,
-                                  ),
-                                ),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          Icons.calendar_today,
-                                          size: 16,
-                                          color: Colors.grey.shade600,
-                                        ),
-                                        const SizedBox(width: 4),
-                                        Text(
-                                          'startdate'.tr,
-                                          style: TextStyle(
-                                            fontSize: 12,
+                                  Padding(
+                                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                                    child: Container(
+                                      decoration: BoxDecoration(
+                                        color: Colors.grey.shade50,
+                                        borderRadius: BorderRadius.circular(16),
+                                        border: Border.all(color: Colors.grey.shade200),
+                                      ),
+                                      child: TextFormField(
+                                        controller: controller.titleController,
+                                        decoration: InputDecoration(
+                                          labelText: 'taskname'.tr,
+                                          hintText: 'hintnametask'.tr,
+                                          border: OutlineInputBorder(
+                                            borderRadius: BorderRadius.circular(16),
+                                            borderSide: BorderSide.none,
+                                          ),
+                                          prefixIcon: Container(
+                                            margin: const EdgeInsets.all(8),
+                                            decoration: BoxDecoration(
+                                              gradient: LinearGradient(
+                                                colors: [
+                                                  (controller.priorityColors[controller.priority.value] ?? kPrimary1).withOpacity(0.2),
+                                                  (controller.priorityColors[controller.priority.value] ?? kPrimary1).withOpacity(0.1),
+                                                ],
+                                              ),
+                                              borderRadius: BorderRadius.circular(8),
+                                            ),
+                                            child: Icon(
+                                              Icons.edit,
+                                              color: controller.priorityColors[controller.priority.value] ?? kPrimary1,
+                                              size: 20,
+                                            ),
+                                          ),
+                                          filled: true,
+                                          fillColor: Colors.transparent,
+                                          labelStyle: TextStyle(
                                             color: Colors.grey.shade600,
                                             fontWeight: FontWeight.w500,
                                           ),
                                         ),
-                                      ],
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      _formatDate(controller.startDate.value),
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w600,
+                                        style: const TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                        validator: (value) {
+                                          if (value == null || value.trim().isEmpty) {
+                                            return 'inserttaskname'.tr;
+                                          }
+                                          return null;
+                                        },
+                                        textInputAction: TextInputAction.next,
                                       ),
                                     ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: GestureDetector(
-                              onTap: () => controller.pickDate(context, false),
-                              child: Container(
-                                padding: const EdgeInsets.all(16),
-                                decoration: BoxDecoration(
-                                  color: Colors.grey.shade50,
-                                  borderRadius: BorderRadius.circular(12),
-                                  border: Border.all(
-                                    color: Colors.grey.shade300,
                                   ),
-                                ),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      children: [
-                                        Icon(
-                                          Icons.event,
-                                          size: 16,
-                                          color: Colors.grey.shade600,
-                                        ),
-                                        const SizedBox(width: 4),
-                                        Text(
-                                          'duedate'.tr,
-                                          style: TextStyle(
-                                            fontSize: 12,
-                                            color: Colors.grey.shade600,
-                                            fontWeight: FontWeight.w500,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      _formatDate(controller.endDate.value),
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                    ),
-                                  ],
-                                ),
+                                ],
                               ),
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
 
-              const SizedBox(height: 16),
-
-              // Checklist Card
-              Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Row(
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.all(8),
-                                decoration: BoxDecoration(
-                                  color: Colors.purple.withOpacity(0.1),
-                                  borderRadius: BorderRadius.circular(8),
-                                ),
-                                child: const Icon(
-                                  Icons.checklist,
-                                  color: Colors.purple,
-                                  size: 20,
-                                ),
-                              ),
-                              const SizedBox(width: 12),
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+                            // Priority and Dates Section
+                            _buildGlassmorphismCard(
+                              delay: 0.1,
+                              child: Column(
                                 children: [
-                                  Text(
-                                    'subtasks'.tr,
-                                    style: TextStyle(
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.w600,
+                                  _buildSectionHeader(
+                                    icon: Icons.tune,
+                                    title: 'settings'.tr,
+                                    gradient: const [Color(0xFF74b9ff), Color(0xFF0984e3)],
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                                    child: Column(
+                                      children: [
+                                        // Priority Selector
+                                        Container(
+                                          padding: const EdgeInsets.all(4),
+                                          decoration: BoxDecoration(
+                                            color: Colors.grey.shade100,
+                                            borderRadius: BorderRadius.circular(16),
+                                            border: Border.all(color: Colors.grey.shade200),
+                                          ),
+                                          child: Row(
+                                            children: ['low'.tr, 'medium'.tr, 'high'.tr].map((p) {
+                                              final isSelected = controller.priority.value == p;
+                                              final priorityColor = controller.priorityColors[p] ?? kPrimary1;
+                                              
+                                              return Expanded(
+                                                child: GestureDetector(
+                                                  onTap: () => controller.priority.value = p,
+                                                  child: AnimatedContainer(
+                                                    duration: const Duration(milliseconds: 300),
+                                                    curve: Curves.easeInOut,
+                                                    margin: const EdgeInsets.all(2),
+                                                    padding: const EdgeInsets.symmetric(vertical: 14),
+                                                    decoration: BoxDecoration(
+                                                      gradient: isSelected
+                                                          ? LinearGradient(
+                                                              colors: [
+                                                                priorityColor,
+                                                                priorityColor.withOpacity(0.8),
+                                                              ],
+                                                            )
+                                                          : null,
+                                                      borderRadius: BorderRadius.circular(12),
+                                                      boxShadow: isSelected
+                                                          ? [
+                                                              BoxShadow(
+                                                                color: priorityColor.withOpacity(0.3),
+                                                                blurRadius: 8,
+                                                                offset: const Offset(0, 4),
+                                                              ),
+                                                            ]
+                                                          : null,
+                                                    ),
+                                                    child: Row(
+                                                      mainAxisAlignment: MainAxisAlignment.center,
+                                                      children: [
+                                                        Icon(
+                                                          controller.priorityIcons[p],
+                                                          color: isSelected ? Colors.white : priorityColor,
+                                                          size: 20,
+                                                        ),
+                                                        const SizedBox(width: 6),
+                                                        Text(
+                                                          p.toLowerCase().tr,
+                                                          style: TextStyle(
+                                                            color: isSelected ? Colors.white : priorityColor,
+                                                            fontWeight: FontWeight.w600,
+                                                            fontSize: 14,
+                                                          ),
+                                                        ),
+                                                      ],
+                                                    ),
+                                                  ),
+                                                ),
+                                              );
+                                            }).toList(),
+                                          ),
+                                        ),
+
+                                        const SizedBox(height: 24),
+
+                                        // Date Pickers
+                                        Container(
+                                          padding: const EdgeInsets.all(16),
+                                          decoration: BoxDecoration(
+                                            color: Colors.grey.withOpacity(0.05),
+                                            borderRadius: BorderRadius.circular(16),
+                                            border: Border.all(color: Colors.grey.withOpacity(0.1)),
+                                          ),
+                                          child: Row(
+                                            children: [
+                                              Expanded(
+                                                child: GestureDetector(
+                                                  onTap: () => controller.pickDate(context, true),
+                                                  child: _buildDateInfo(
+                                                    'startdate'.tr,
+                                                    controller.startDate.value,
+                                                    Icons.play_circle_filled_rounded,
+                                                    const Color(0xFF00b894),
+                                                  ),
+                                                ),
+                                              ),
+                                              Container(
+                                                width: 1,
+                                                height: 40,
+                                                color: Colors.grey.withOpacity(0.2),
+                                                margin: const EdgeInsets.symmetric(horizontal: 16),
+                                              ),
+                                              Expanded(
+                                                child: GestureDetector(
+                                                  onTap: () => controller.pickDate(context, false),
+                                                  child: _buildDateInfo(
+                                                    'duedate'.tr,
+                                                    controller.endDate.value,
+                                                    Icons.flag_rounded,
+                                                    kPrimary2,
+                                                  ),
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                   ),
-                                  Text(
-                                    'list_item'.trParams({
+                                ],
+                              ),
+                            ),
+
+                            // Checklist Section
+                            _buildGlassmorphismCard(
+                              delay: 0.2,
+                              child: Column(
+                                children: [
+                                  _buildSectionHeader(
+                                    icon: Icons.checklist_rtl,
+                                    title: 'subtasks'.tr,
+                                    subtitle: 'list_item'.trParams({
                                       'count': controller.checklist.length.toString(),
                                     }),
-                                    style: TextStyle(
-                                      fontSize: 12,
-                                      color: Colors.grey.shade600,
+                                    gradient: const [Color(0xFF8B5CF6), Color(0xFF7C3AED)],
+                                    action: _buildGradientActionButton(
+                                      icon: Icons.add,
+                                      gradient: const [Color(0xFF8B5CF6), Color(0xFF7C3AED)],
+                                      onPressed: controller.addChecklistItem,
+                                      label: 'add'.tr,
                                     ),
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                                    child: controller.checklist.isEmpty
+                                        ? _buildEmptyChecklistState()
+                                        : _buildChecklistItems(),
                                   ),
                                 ],
                               ),
-                            ],
-                          ),
-                          ElevatedButton.icon(
-                            onPressed: controller.addChecklistItem,
-                            icon: const Icon(Icons.add, size: 18),
-                            label: Text('add'.tr),
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.purple,
-                              foregroundColor: Colors.white,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20),
-                              ),
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 8,
-                              ),
                             ),
-                          ),
-                        ],
-                      ),
 
-                      if (controller.checklist.isEmpty) ...[
-                        const SizedBox(height: 20),
-                        Center(
-                          child: Column(
-                            children: [
-                              Icon(
-                                Icons.checklist,
-                                size: 48,
-                                color: Colors.grey.shade400,
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                'nosubtasks'.tr,
-                                style: TextStyle(
-                                  color: Colors.grey.shade600,
-                                  fontSize: 14,
-                                ),
-                              ),
-                              Text(
-                                'guidelinessubtasks'.tr,
-                                style: TextStyle(
-                                  color: Colors.grey.shade500,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ],
-                          ),
+                            const SizedBox(height: 20),
+                          ],
                         ),
-                      ] else ...[
-                        const SizedBox(height: 16),
-                        ...controller.checklist.asMap().entries.map((entry) {
-                          int index = entry.key;
-                          var item = entry.value;
-
-                          return Container(
-                            margin: const EdgeInsets.only(bottom: 12),
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: item["done"] == true
-                                    ? Colors.green.shade200
-                                    : Colors.grey.shade300,
-                              ),
-                              color: item["done"] == true
-                                  ? Colors.green.shade50
-                                  : Colors.white,
-                            ),
-                            child: ExpansionTile(
-                              key: ValueKey(item["id"]),
-                              initiallyExpanded: item["expanded"] ?? true,
-                              onExpansionChanged: (expanded) {
-                                controller.toggleChecklistExpansion(
-                                    index, expanded);
-                              },
-                              leading: Checkbox(
-                                value: item["done"],
-                                onChanged: (val) {
-                                  controller.toggleChecklistDone(
-                                      index, val!);
-                                },
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(4),
-                                ),
-                              ),
-                              title: TextField(
-                                readOnly: item["done"] ?? false,
-                                decoration: InputDecoration(
-                                  hintText: "subtaskname".tr,
-                                  border: InputBorder.none,
-                                  isDense: true,
-                                ),
-                                controller:
-                                    TextEditingController(text: item["title"])
-                                      ..selection = TextSelection.collapsed(
-                                        offset: item["title"]?.length ?? 0,
-                                      ),
-                                style: TextStyle(
-                                  color: (item["done"] ?? false)
-                                      ? Colors.grey
-                                      : Colors.black,
-                                  decoration: (item["done"] ?? false)
-                                      ? TextDecoration.lineThrough
-                                      : TextDecoration.none,
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w500,
-                                ),
-                                onChanged: (val) => item["title"] = val,
-                              ),
-                              trailing: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  IconButton(
-                                    icon: const Icon(
-                                      Icons.delete_outline,
-                                      color: Colors.red,
-                                      size: 20,
-                                    ),
-                                    onPressed: () => controller.removeChecklistItem(context, index),
-                                  ),
-                                  RotationTransition(
-                                    turns: AlwaysStoppedAnimation(
-                                      (item["expanded"] ?? true) ? 0.5 : 0.0,
-                                    ),
-                                    child: const Icon(Icons.expand_more),
-                                  ),
-                                ],
-                              ),
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.fromLTRB(
-                                    16,
-                                    0,
-                                    16,
-                                    16,
-                                  ),
-                                  child: TextField(
-                                    readOnly: item["done"] ?? false,
-                                    decoration: InputDecoration(
-                                      hintText: "subtaskdetails".tr,
-                                      border: OutlineInputBorder(
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      filled: true,
-                                      fillColor: Colors.grey.shade50,
-                                    ),
-                                    maxLines: 2,
-                                    controller: TextEditingController(
-                                      text: item["description"],
-                                    ),
-                                    style: TextStyle(
-                                      color: (item["done"] ?? false)
-                                          ? Colors.grey
-                                          : Colors.black,
-                                      fontSize: 14,
-                                    ),
-                                    onChanged: (val) =>
-                                        item["description"] = val,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          );
-                        }).toList(),
-                      ],
-                    ],
+                      ),
+                    ),
                   ),
                 ),
-              ),
-
-              const SizedBox(height: 24),
             ],
           ),
         ),
       ),
-      bottomNavigationBar: Container(
+      bottomNavigationBar: _buildModernBottomBar(),
+    );
+  }
+
+  Widget _buildModernAppBar() {
+    return FadeTransition(
+      opacity: _fadeAnimation,
+      child: Container(
         padding: const EdgeInsets.all(20),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.05),
-              blurRadius: 10,
-              offset: const Offset(0, -5),
+        child: Row(
+          children: [
+            IconButton(
+              onPressed: () => Get.back(),
+              icon: const Icon(
+                Icons.arrow_back_ios_new_rounded,
+                color: Colors.white,
+              ),
             ),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withOpacity(0.3)),
+              ),
+              child: const Icon(
+                Icons.add_task_rounded,
+                color: Colors.white,
+                size: 28,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'addnewtask'.tr,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    'createyourtask'.tr,
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.85),
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Obx(() => controller.isLoading.value
+                ? Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.2),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2.5,
+                      ),
+                    ),
+                  )
+                : const SizedBox()),
           ],
         ),
-        child: SafeArea(
-          child: SizedBox(
-            height: 56,
-            child: ElevatedButton.icon(
-              onPressed: controller.isLoading.value
-                  ? null
-                  : () => controller.saveTask(_formKey, context),
-              icon: controller.isLoading.value
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                      ),
-                    )
-                  : const Icon(Icons.save, size: 22),
-              label: Text(
-                controller.isLoading.value ? 'saving'.tr : 'savetask'.tr,
+      ),
+    );
+  }
+
+  Widget _buildDateInfo(String label, DateTime date, IconData icon, Color color) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            color: color.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(icon, size: 16, color: color),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Colors.grey[600],
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              Text(
+                _formatDate(date),
                 style: const TextStyle(
-                  fontSize: 16,
+                  fontSize: 13,
+                  color: Color(0xFF2D3748),
                   fontWeight: FontWeight.w600,
                 ),
               ),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: controller.priorityColors[controller.priority.value],
-                foregroundColor: Colors.white,
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGradientActionButton({
+    required IconData icon,
+    required List<Color> gradient,
+    required VoidCallback onPressed,
+    String? label,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(colors: gradient),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: gradient.first.withOpacity(0.3),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: onPressed,
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: label != null ? 16 : 12,
+              vertical: 12,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: Colors.white, size: 18),
+                if (label != null) ...[
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyChecklistState() {
+    return Container(
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Colors.grey.withOpacity(0.05),
+            Colors.grey.withOpacity(0.02),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade100,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.checklist_rtl,
+              size: 48,
+              color: Colors.grey.shade400,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'nosubtasks'.tr,
+            style: TextStyle(
+              color: Colors.grey.shade700,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'guidelinessubtasks'.tr,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Colors.grey.shade500,
+              fontSize: 14,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChecklistItems() {
+    return Column(
+      children: controller.checklist.asMap().entries.map((entry) {
+        int index = entry.key;
+        var item = entry.value;
+
+        return Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: item["done"] == true
+                  ? Colors.green.shade300
+                  : Colors.grey.shade200,
+              width: 1.5,
+            ),
+            gradient: LinearGradient(
+              colors: item["done"] == true
+                  ? [
+                      Colors.green.shade50,
+                      Colors.green.shade100.withOpacity(0.5),
+                    ]
+                  : [
+                      Colors.white,
+                      Colors.grey.shade50.withOpacity(0.5),
+                    ],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.02),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: ExpansionTile(
+            key: ValueKey(item["id"]),
+            initiallyExpanded: item["expanded"] ?? true,
+            onExpansionChanged: (expanded) {
+              controller.toggleChecklistExpansion(index, expanded);
+            },
+            leading: Container(
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: item["done"] == true ? Colors.green : Colors.grey.shade300,
+                  width: 2,
+                ),
+                color: item["done"] == true ? Colors.green : Colors.transparent,
+              ),
+              child: Checkbox(
+                value: item["done"],
+                onChanged: (val) {
+                  controller.toggleChecklistDone(index, val!);
+                },
+                activeColor: Colors.transparent,
+                checkColor: Colors.white,
+                side: BorderSide.none,
+
+              ),
+            ),
+            title: Container(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: TextField(
+                readOnly: item["done"] ?? false,
+                decoration: InputDecoration(
+                  hintText: "subtaskname".tr,
+                  border: InputBorder.none,
+                  isDense: true,
+                ),
+                controller: TextEditingController(text: item["title"])
+                  ..selection = TextSelection.collapsed(
+                    offset: item["title"]?.length ?? 0,
+                  ),
+                style: TextStyle(
+                  color: (item["done"] ?? false) ? Colors.grey.shade600 : Colors.black87,
+                  decoration: (item["done"] ?? false)
+                      ? TextDecoration.lineThrough
+                      : TextDecoration.none,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+                onChanged: (val) => item["title"] = val,
+              ),
+            ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    color: Colors.red.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: IconButton(
+                    icon: Icon(
+                      Icons.delete_outline,
+                      color: Colors.red.shade600,
+                      size: 20,
+                    ),
+                    onPressed: () => controller.removeChecklistItem(context, index),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                AnimatedRotation(
+                  turns: (item["expanded"] ?? true) ? 0.5 : 0.0,
+                  duration: const Duration(milliseconds: 300),
+                  child: Icon(
+                    Icons.expand_more,
+                    color: Colors.grey.shade600,
+                  ),
+                ),
+              ],
+            ),
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade50,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Colors.grey.shade200),
+                  ),
+                  child: TextField(
+                    readOnly: item["done"] ?? false,
+                    decoration: InputDecoration(
+                      hintText: "subtaskdetails".tr,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      fillColor: Colors.transparent,
+                      contentPadding: const EdgeInsets.all(16),
+                    ),
+                    maxLines: 3,
+                    controller: TextEditingController(
+                      text: item["description"],
+                    ),
+                    style: TextStyle(
+                      color: (item["done"] ?? false)
+                          ? Colors.grey.shade600
+                          : Colors.black87,
+                      fontSize: 14,
+                    ),
+                    onChanged: (val) => item["description"] = val,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildModernBottomBar() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            blurRadius: 20,
+            offset: const Offset(0, -8),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        child: SizedBox(
+          height: 60,
+          child: Obx(() => Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      controller.priorityColors[controller.priority.value] ?? kPrimary1,
+                      (controller.priorityColors[controller.priority.value] ?? kPrimary1)
+                          .withOpacity(0.8),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: (controller.priorityColors[controller.priority.value] ?? kPrimary1)
+                          .withOpacity(0.4),
+                      blurRadius: 15,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: ElevatedButton.icon(
+                  onPressed: controller.isLoading.value
+                      ? null
+                      : () => controller.saveTask(_formKey, context),
+                  icon: controller.isLoading.value
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : const Icon(Icons.save_rounded, size: 24),
+                  label: Text(
+                    controller.isLoading.value ? 'saving'.tr : 'savetask'.tr,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.transparent,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shadowColor: Colors.transparent,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
         ),
       ),
     );

--- a/lib/pages/task_list_page.dart
+++ b/lib/pages/task_list_page.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import '../../controllers/dashboard_controller.dart';
 import '../../models/task_model.dart';
-import 'task_detail_page.dart';
 
 class TaskListPage extends StatefulWidget {
   const TaskListPage({super.key});
@@ -15,7 +14,8 @@ class TaskListPage extends StatefulWidget {
   State<TaskListPage> createState() => _TaskListPageState();
 }
 
-class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMixin {
+class _TaskListPageState extends State<TaskListPage>
+    with TickerProviderStateMixin {
   final DashboardController controller = Get.find<DashboardController>();
   final formattedDate = ''.obs;
   late AnimationController _fadeController;
@@ -47,15 +47,14 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
       vsync: this,
     );
 
-    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
-      CurvedAnimation(parent: _fadeController, curve: Curves.easeOut),
-    );
-    _slideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.3),
-      end: Offset.zero,
-    ).animate(
-      CurvedAnimation(parent: _slideController, curve: Curves.elasticOut),
-    );
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(parent: _fadeController, curve: Curves.easeOut));
+    _slideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.3), end: Offset.zero).animate(
+          CurvedAnimation(parent: _slideController, curve: Curves.elasticOut),
+        );
 
     _fadeController.forward();
     _slideController.forward();
@@ -123,13 +122,18 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
       case 'todo':
         return allTasks.where((t) => t.status.toLowerCase() == 'todo').toList();
       case 'in_progress':
-        return allTasks.where((t) => t.status.toLowerCase() == 'in_progress').toList();
+        return allTasks
+            .where((t) => t.status.toLowerCase() == 'in_progress')
+            .toList();
       case 'done':
         return allTasks.where((t) => t.status.toLowerCase() == 'done').toList();
       case 'overdue':
         final now = DateTime.now();
         return allTasks
-            .where((t) => t.status.toLowerCase() != 'done' && t.endDate.isBefore(now))
+            .where(
+              (t) =>
+                  t.status.toLowerCase() != 'done' && t.endDate.isBefore(now),
+            )
             .toList();
       case 'all':
       default:
@@ -139,23 +143,17 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
 
   List<TaskModel> _sortTasksByStatus(List<TaskModel> tasks) {
     final now = DateTime.now();
-    const priority = {
-      'in_progress': 1,
-      'todo': 2,
-      'overdue': 3,
-      'done': 4,
-    };
+    const priority = {'in_progress': 1, 'todo': 2, 'overdue': 3, 'done': 4};
 
-    return tasks
-      ..sort((a, b) {
-        String statusA = a.status.toLowerCase();
-        String statusB = b.status.toLowerCase();
+    return tasks..sort((a, b) {
+      String statusA = a.status.toLowerCase();
+      String statusB = b.status.toLowerCase();
 
-        if (statusA != 'done' && a.endDate.isBefore(now)) statusA = 'overdue';
-        if (statusB != 'done' && b.endDate.isBefore(now)) statusB = 'overdue';
+      if (statusA != 'done' && a.endDate.isBefore(now)) statusA = 'overdue';
+      if (statusB != 'done' && b.endDate.isBefore(now)) statusB = 'overdue';
 
-        return (priority[statusA] ?? 99).compareTo(priority[statusB] ?? 99);
-      });
+      return (priority[statusA] ?? 99).compareTo(priority[statusB] ?? 99);
+    });
   }
 
   @override
@@ -185,10 +183,7 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
                     ),
                   ),
                   child: CustomScrollView(
-                    slivers: [
-                      _buildFilterChips(),
-                      _buildTasksList(),
-                    ],
+                    slivers: [_buildFilterChips(), _buildTasksList()],
                   ),
                 ),
               ),
@@ -208,11 +203,12 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
         child: Row(
           children: [
             IconButton(
-                onPressed: () => Get.back(),
-                icon: const Icon(
-                  Icons.arrow_back_ios_new_rounded,
-                  color: Colors.white,
-                )),
+              onPressed: () => Get.back(),
+              icon: const Icon(
+                Icons.arrow_back_ios_new_rounded,
+                color: Colors.white,
+              ),
+            ),
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
@@ -281,9 +277,14 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
                     setState(() => selectedStatus = key);
                   },
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 12,
+                    ),
                     decoration: BoxDecoration(
-                      gradient: isSelected ? LinearGradient(colors: gradient) : null,
+                      gradient: isSelected
+                          ? LinearGradient(colors: gradient)
+                          : null,
                       color: isSelected ? null : Colors.white,
                       borderRadius: BorderRadius.circular(25),
                       boxShadow: [
@@ -337,7 +338,9 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
                     // ✅ โหลดด้วยกราเดียนต์เขียว
-                    gradient: const LinearGradient(colors: [kPrimary1, kPrimary2]),
+                    gradient: const LinearGradient(
+                      colors: [kPrimary1, kPrimary2],
+                    ),
                     borderRadius: BorderRadius.circular(20),
                   ),
                   child: const CircularProgressIndicator(
@@ -397,10 +400,7 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
                 const SizedBox(height: 8),
                 Text(
                   'startcreatetask'.tr,
-                  style: TextStyle(
-                    color: Colors.grey[500],
-                    fontSize: 14,
-                  ),
+                  style: TextStyle(color: Colors.grey[500], fontSize: 14),
                 ),
               ],
             ),
@@ -497,7 +497,12 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        _buildCardHeader(task, gradientColors, statusIcon, isDone),
+                        _buildCardHeader(
+                          task,
+                          gradientColors,
+                          statusIcon,
+                          isDone,
+                        ),
                         const SizedBox(height: 16),
                         _buildDateSection(task, isOverdue),
                         if (isOverdue) ...[
@@ -519,7 +524,11 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
   }
 
   Widget _buildCardHeader(
-      TaskModel task, List<Color> gradientColors, IconData statusIcon, bool isDone) {
+    TaskModel task,
+    List<Color> gradientColors,
+    IconData statusIcon,
+    bool isDone,
+  ) {
     return Row(
       children: [
         Container(
@@ -555,7 +564,10 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
               ),
               const SizedBox(height: 6),
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 4,
+                ),
                 decoration: BoxDecoration(
                   gradient: LinearGradient(colors: gradientColors),
                   borderRadius: BorderRadius.circular(20),
@@ -642,7 +654,10 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
   }
 
   Widget _buildActionButtons(
-      TaskModel task, bool isDone, List<Color> gradientColors) {
+    TaskModel task,
+    bool isDone,
+    List<Color> gradientColors,
+  ) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
@@ -707,7 +722,12 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
     );
   }
 
-  Widget _buildDateInfo(String label, DateTime date, IconData icon, Color color) {
+  Widget _buildDateInfo(
+    String label,
+    DateTime date,
+    IconData icon,
+    Color color,
+  ) {
     final locale = Get.locale?.toString() ?? 'en_US';
     final formatter = DateFormat('dd MMM yyyy', locale);
 
@@ -802,8 +822,9 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
           children: [
             Container(
               padding: const EdgeInsets.all(8),
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 gradient: LinearGradient(colors: [kPrimary1, kPrimary2]),
+                borderRadius: BorderRadius.circular(10),
               ),
               child: const Icon(Icons.task_alt, color: Colors.white),
             ),
@@ -821,15 +842,16 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
             child: Text('cancel'.tr, style: TextStyle(color: Colors.grey[600])),
           ),
           Container(
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               gradient: LinearGradient(colors: [kPrimary1, kPrimary2]),
+              borderRadius: BorderRadius.circular(10)
             ),
             child: TextButton(
               onPressed: () {
                 controller.updateTaskStatus(task.id, 'done');
                 Navigator.pop(context);
               },
-              child: const Text('confirm', style: TextStyle(color: Colors.white)),
+              child: Text('confirm'.tr, style: TextStyle(color: Colors.white)),
             ),
           ),
         ],
@@ -847,8 +869,11 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
           children: [
             Container(
               padding: const EdgeInsets.all(8),
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(colors: [Color(0xFFe17055), Color(0xFFd63031)]),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [Color(0xFFe17055), Color(0xFFd63031)],
+                ),
+                borderRadius: BorderRadius.circular(10),
               ),
               child: const Icon(Icons.delete_outline, color: Colors.white),
             ),
@@ -866,15 +891,21 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
             child: Text('cancel'.tr, style: TextStyle(color: Colors.grey[600])),
           ),
           Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(colors: [Color(0xFFe17055), Color(0xFFd63031)]),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [Color(0xFFe17055), Color(0xFFd63031)],
+              ),
+              borderRadius: BorderRadius.circular(10)
             ),
             child: TextButton(
               onPressed: () {
                 controller.deleteTask(task.id);
                 Navigator.pop(context);
               },
-              child: const Text('confirm', style: TextStyle(color: Colors.white)),
+              child: Text(
+                'confirm'.tr,
+                style: TextStyle(color: Colors.white),
+              ),
             ),
           ),
         ],
@@ -892,8 +923,11 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
           children: [
             Container(
               padding: const EdgeInsets.all(8),
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(colors: [Color(0xFFfdcb6e), Color(0xFFe17055)]),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [Color(0xFFfdcb6e), Color(0xFFe17055)],
+                ),
+                borderRadius: BorderRadius.circular(10)
               ),
               child: const Icon(Icons.work, color: Colors.white),
             ),
@@ -911,15 +945,21 @@ class _TaskListPageState extends State<TaskListPage> with TickerProviderStateMix
             child: Text('cancel'.tr, style: TextStyle(color: Colors.grey[600])),
           ),
           Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(colors: [Color(0xFFfdcb6e), Color(0xFFe17055)]),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [Color(0xFFfdcb6e), Color(0xFFe17055)],
+              ),
+              borderRadius: BorderRadius.circular(10)
             ),
             child: TextButton(
               onPressed: () {
                 controller.updateTaskStatus(task.id, 'in_progress');
                 Navigator.pop(context);
               },
-              child: const Text('confirm', style: TextStyle(color: Colors.white)),
+              child: Text(
+                'confirm'.tr,
+                style: TextStyle(color: Colors.white),
+              ),
             ),
           ),
         ],

--- a/lib/services/ai_api_service.dart
+++ b/lib/services/ai_api_service.dart
@@ -3,7 +3,7 @@ import 'package:http/http.dart' as http;
 import '../models/task_model.dart';
 
 class AiApiService {
-  static const String baseUrl = "https://9b6ef6a3191e.ngrok-free.app";
+  static const String baseUrl = "https://ad82abb18af5.ngrok-free.app";
 
   static Future<TaskModel> fetchTaskFromAi(String input) async {
     final response = await http.post(

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -60,7 +60,7 @@ class LocalizationService extends Translations {
       'dialogconfirmstatus': 'คุณต้องการเปลี่ยนสถานะงาน เป็นเสร็จแล้ว หรือไม่?',
       'comfirmdelete': 'ยืนยันการลบงาน',
       'dialogconfirmdelete': 'คุณแน่ใจว่าต้องการลบงาน หรือไม่?',
-      'addnewtask': 'เพิ่ม งาน ใหม่',
+      'addnewtask': 'เพิ่มงานใหม่',
       'taskdetails': 'แก้ไขรายละเอียดงาน',
       'taskname': 'ชื่องาน',
       'settings': 'การตั้งค่า',
@@ -170,7 +170,7 @@ class LocalizationService extends Translations {
       "cannotSaveTask": "ไม่สามารถบันทึก Task ได้",
       "savedMainTaskWithNSubtasks":
           "บันทึก Task หลักพร้อม {{count}} รายการย่อยเรียบร้อยแล้ว ✓",
-
+      'createyourtask': 'สร้าง Task ของคุณ',    
       "jan": "ม.ค.",
       "feb": "ก.พ.",
       "mar": "มี.ค.",
@@ -255,10 +255,11 @@ class LocalizationService extends Translations {
       'cancel': 'Cancel',
       'confirm': 'Confirm',
       'register': 'Register',
+      'delete': 'Delete',
       'email': 'Email',
       'ai-import': 'AI-Import',
       'analytics': 'Analytics',
-      'ai-task-manager': 'AI Task Manager',
+      'ai-task-manager': 'AI Task Management',
       'password': 'Password',
       'todaytasks': 'Today Tasks',
       'taskincoming(3days)': 'Upcoming Tasks (3 Days)',
@@ -302,7 +303,7 @@ class LocalizationService extends Translations {
       'nosubtasks': 'No subtasks yet',
       'guidelinessubtasks': 'Tap "Add" to create a subtask',
       'savetask': 'Save Task',
-      'confirmdeletesubtask': 'do you want to delete this subtask?',
+      'confirmdeletesubtask': 'Do you want to delete this subtask?',
       'hintnametask': 'Enter the name of the task you want to create',
       'inserttaskname': 'Please enter the name of the task',
       'subtaskname': 'Subtask Name',
@@ -497,6 +498,7 @@ class LocalizationService extends Translations {
       "cannotSaveTask": "Unable to save the task",
       "savedMainTaskWithNSubtasks":
           "Saved main task with {{count}} sub-tasks ✓",
+      'createyourtask' : 'Create your task',    
     },
   };
 


### PR DESCRIPTION
## Summary
- add AddTaskController with Firestore-backed saveTask and reactive state
- refactor AddTaskPage to use AddTaskController instead of setState

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fb11bb788322bc7e8aa51d2d892d